### PR TITLE
Remove trailing slash from frontUrl

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import bodyParser from 'body-parser';
 
 export const frontId = 'yourFrontId';
 export const frontSecret = 'shhhhhhhhh';
-export const frontUrl = 'https://api2.frontapp.com/';
+export const frontUrl = 'https://api2.frontapp.com';
 export const callbackHostname = 'https://your-ngrok-hostnmae.ngrok.io';
 export const serverPort = '3000';
 


### PR DESCRIPTION
This is only used in front_connector.ts where it's called as:

```
const endpoint = `${frontUrl}/channels/${channelId}/inbound_messages`;
```

This results in the url `https://api2.frontapp.com//channels...` which is invalid and results in a confusing 403 error: `Token cannot access path: //channels...`